### PR TITLE
Added support for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,25 @@ notifications:
         on_success: never
         on_failure: always
 
-php:
-  - 7.2
-
-env:
-  - LARAVEL_VERSION=6.0.*
+matrix:
+  include:
+    - php: 7.2
+      env: LARAVEL_VERSION='6.0*' TESTBENCH='4.0'
+    - php: 7.3
+      env: LARAVEL_VERSION='6.0*' TESTBENCH='4.0'
+    - php: 7.4
+      env: LARAVEL_VERSION='6.0*' TESTBENCH='4.0'
+    - php: 7.2
+      env: LARAVEL_VERSION='7.*' TESTBENCH='5.0'
+    - php: 7.3
+      env: LARAVEL_VERSION='7.*' TESTBENCH='5.0'
+    - php: 7.4
+      env: LARAVEL_VERSION='7.*' TESTBENCH='5.0'
 
 before_install:
   - travis_retry composer self-update --stable -n
   - composer validate --no-check-all --strict
-  - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update -n
+  - composer require "laravel/framework:${LARAVEL_VERSION}" "orchestra/testbench:${TESTBENCH}" "orchestra/testbench-browser-kit:${TESTBENCH}" --no-update -n
 
 install:
   - travis_retry composer install --no-suggest --prefer-dist -n -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ notifications:
 matrix:
   include:
     - php: 7.2
-      env: LARAVEL_VERSION='6.0*' TESTBENCH='4.0'
+      env: LARAVEL_VERSION='6.0.*' TESTBENCH='4.0'
     - php: 7.3
-      env: LARAVEL_VERSION='6.0*' TESTBENCH='4.0'
+      env: LARAVEL_VERSION='6.0.*' TESTBENCH='4.0'
     - php: 7.4
-      env: LARAVEL_VERSION='6.0*' TESTBENCH='4.0'
+      env: LARAVEL_VERSION='6.0.*' TESTBENCH='4.0'
     - php: 7.2
       env: LARAVEL_VERSION='7.*' TESTBENCH='5.0'
     - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
   ],
    "require": {
     "php": ">=7.2",
-    "laravel/framework": "~6.0",
+    "laravel/framework": "~6.0||~7.0",
     "layershifter/tld-extract": "^2.0"
   },
   "require-dev": {
-    "orchestra/testbench": "~4.0",
-    "orchestra/testbench-browser-kit": "~4.0",
-    "phpunit/phpunit": "^8.3"
+    "orchestra/testbench": "~5.0",
+    "orchestra/testbench-browser-kit": "~5.0",
+    "phpunit/phpunit": "^8.5"
   },
   "autoload": {
     "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -130,7 +130,7 @@ class TestCase extends OrchestraTestCase
      *
      * @return bool
      */
-    protected function responseHasCookies(Response $response, $cookies)
+    protected function responseHasCookies($response, $cookies)
     {
         $responseCookies = $response->headers->getCookies();
 


### PR DESCRIPTION
I've added support for laravel 7. 

The travis configuration has been updated to test laravel 6 and 7 with php 7.2 to php 7.4.

Since Testbench Browser Kit 5 for Laravel 7 is using `Laravel\BrowserKitTesting\TestResponse` and Testbench Browser Kit 4 (for laravel 6) is using `Illuminate\Http\Response`, I needed to remove the typehint in the "responseHasCookies" function in the TestCase.